### PR TITLE
Propagate initialization error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
+# 2.8.0.0
+* Return record `InitializedCell` in `initializeXXXStore` which carry the cell
+  and any initialization errors.
+
 # 2.7.0.0
 
-* rename `makeUpdateXSimpleCell` to `makeRepsertXSimpleCell` and resulting 
+* rename `makeUpdateXSimpleCell` to `makeRepsertXSimpleCell` and resulting
 function starts with `repsert` instead of `update`.
 
 # 2.6.0.1

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: simple-cell
-version: '2.7.0.0'
+version: '2.8.0.0'
 synopsis: Batch Processing of resumable states
 description: SimpleCell uses SimpleStore and self generating keys to create batch operations on datatypes
 category: DB
@@ -17,9 +17,9 @@ flags:
 
 library:
   source-dirs: src
-  exposed-modules:      
-  - SimpleStore.Cell                    
-  other-modules:        
+  exposed-modules:
+  - SimpleStore.Cell
+  other-modules:
   - SimpleStore.Cell.Internal
   - SimpleStore.Cell.Types
   - SimpleStore.Cell.DIG
@@ -30,9 +30,9 @@ library:
   - aeson-serialize >= 0.0.0
   - async >= 2.0.0
   - base >=4.7 && <5
-  - basic-prelude >= 0.3.0                      
+  - basic-prelude >= 0.3.0
   - bytestring >= 0.10.0.2
-  - cereal >= 0.4.0.1                      
+  - cereal >= 0.4.0.1
   - containers >= 0.5.0.0
   - directed-keys >= 0.3.1
   - hashable >= 1.2.2.0
@@ -41,12 +41,12 @@ library:
   - plow-extras-list >= 0.1.0
   - simple-store == 4.0.0
   - stm >= 2.4.3
-  - stm-containers >= 0.2.7 
+  - stm-containers >= 0.2.7
   - system-fileio >= 0.3.12
   - system-filepath >= 0.4.10
-  - template-haskell 
+  - template-haskell
   - text >= 1.1.0.1
-  ghc-options:          
+  ghc-options:
   - -Wall
   - -Werror
 
@@ -66,14 +66,14 @@ tests:
     - simple-cell
     - simple-store
     - text
-    ghc-options:          
+    ghc-options:
     - -Wall
-    - -Werror    
+    - -Werror
 
 benchmarks:
   simple-cell-bench:
     main: Bench.hs
-    source-dirs: 
+    source-dirs:
     - bench
     - test
     dependencies:
@@ -99,12 +99,12 @@ benchmarks:
         - -prof
         - -auto-all
         - -caf-all
-        - -osuf p_o 
+        - -osuf p_o
         - -hisuf p_hi
       else:
         ghc-options:
-        - -threaded 
-        - -Wall  
-        - -rtsopts 
-        - -fllvm 
+        - -threaded
+        - -Wall
+        - -rtsopts
+        - -fllvm
         - -static

--- a/src/SimpleStore/Cell/DIG.hs
+++ b/src/SimpleStore/Cell/DIG.hs
@@ -311,6 +311,7 @@ initializeSimpleCell' ck emptyTargetState root  = do
 
 
 
+-- | Initialize SimpleCell
 initializeSimpleCell
   :: forall k tm dst src stlive. (Data.Serialize.Serialize stlive , Ord tm, Hashable tm , Ord dst, Hashable dst , Ord src, Hashable src , Ord k, Hashable k)
   => CellKey k src dst tm stlive
@@ -320,6 +321,8 @@ initializeSimpleCell
 initializeSimpleCell ck emptyTargetState root = snd <$> initializeSimpleCell' ck emptyTargetState root
 
 
+-- | Initialize SimpleCell and return errors together with SimpleCell.
+-- The errors and cell are wrapped in 'InitializedCell' record type.
 initializeSimpleCellAndErrors
   :: forall k tm dst src stlive. (Data.Serialize.Serialize stlive , Ord tm, Hashable tm , Ord dst, Hashable dst , Ord src, Hashable src , Ord k, Hashable k)
   => CellKey k src dst tm stlive

--- a/src/SimpleStore/Cell/TH/StoreMakers.hs
+++ b/src/SimpleStore/Cell/TH/StoreMakers.hs
@@ -17,6 +17,7 @@ type StoreName       = Name
 
 allStoreMakers :: [CellKeyName -> InitializerName -> StoreName -> Q Dec]
 allStoreMakers = [ makeInitializeXSimpleCell
+                 , makeInitializeXSimpleCellAndErrors
                  , makeInsertXSimpleCell
                  , makeDeleteXSimpleCell
                  , makeFoldlWithKeyXSimpleCell
@@ -34,11 +35,21 @@ makeInitializeXSimpleCell ckN initN stN = funD (buildInitName stN)
   where
     initializeSimpleCellTH = appE (appE (varE 'initializeSimpleCell ) (varE ckN)) (varE initN)
 
+
+makeInitializeXSimpleCellAndErrors ::  CellKeyName -> InitializerName -> StoreName -> Q Dec
+makeInitializeXSimpleCellAndErrors ckN initN stN = funD (buildInitWithErrorsName stN)
+                                             [clause [] (normalB initializeSimpleCellTH ) []  ]
+  where
+    initializeSimpleCellTH = appE (appE (varE 'initializeSimpleCellAndErrors ) (varE ckN)) (varE initN)
+
 buildInitName :: StoreName -> Name
 buildInitName stN = mkName . concat $ [ "initialize"
                                       , nameBase stN
                                       , "SC"
                                       ]
+
+buildInitWithErrorsName :: StoreName -> Name
+buildInitWithErrorsName stN = mkName . concat $ [ "initialize" , nameBase stN , "WithErrorsSC" ]
 
 makeInsertXSimpleCell ::  CellKeyName -> InitializerName -> StoreName -> Q Dec
 makeInsertXSimpleCell ckN _initN stN = funD (buildInsertName stN)
@@ -85,7 +96,7 @@ makeGetXSimpleCell _ckN _ stN = funD (buildGetName stN)
                                   [clause [] (normalB getSimpleCellTH) [] ]
   where
     getSimpleCellTH = varE 'getStore
-    
+
 buildGetName :: StoreName -> Name
 buildGetName stN = mkName . concat $ [ "get"
                                      , nameBase stN

--- a/src/SimpleStore/Cell/Types.hs
+++ b/src/SimpleStore/Cell/Types.hs
@@ -25,6 +25,7 @@ module SimpleStore.Cell.Types (StoreCellError(..)
                             , SimpleCell (..)
                             , CellCore (..)
                             , FileKey (..)
+                            , InitializedCell(..)
                             ) where
 
 
@@ -144,3 +145,8 @@ data StoreCellError  = InsertFail    !Text
                      | DeleteFail    !Text
                      | StateNotFound !Text
 
+
+data InitializedCell k src dst tm stlive stdormant = InitializedCell
+  { initializedCell       :: SimpleCell k src dst tm stlive stdormant
+  , initializedCellErrors :: [StoreError]
+  } deriving (Typeable, Generic)

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -28,26 +28,26 @@ type SampleCellKey     = CellKey        SampleKey SampleSrc SampleDst SampleTime
 type SampleDirectedKey = DirectedKeyRaw SampleKey SampleSrc SampleDst SampleTime
 
 data Sample = Sample {
-  sampleInt :: Int 
+  sampleInt :: Int
   } deriving (Show,Eq,Generic)
 
 newtype SampleDst = SampleDst { unSampleDst :: Int }
- deriving (Eq,Ord,Generic,Hashable) 
+ deriving (Eq,Ord,Generic,Hashable)
 
 instance Serialize SampleDst where
-  
+
 newtype SampleSrc = SampleSrc { unSampleSrc :: Int }
- deriving (Eq,Ord,Generic ,Hashable) 
+ deriving (Eq,Ord,Generic ,Hashable)
 
 instance Serialize SampleSrc where
 
-newtype SampleKey = SampleKey { unSampleKey :: Int } 
- deriving (Eq,Ord,Generic ,Hashable) 
+newtype SampleKey = SampleKey { unSampleKey :: Int }
+ deriving (Eq,Ord,Generic ,Hashable)
 
 instance Serialize SampleKey where
 
 newtype SampleTime = SampleTime { unSampleTime :: Int }
- deriving (Eq,Ord,Generic ,Hashable) 
+ deriving (Eq,Ord,Generic ,Hashable)
 
 instance Serialize SampleTime where
 
@@ -63,18 +63,18 @@ sampleTime :: SampleTime
 sampleTime = (SampleTime 0)
 
 
-instance ToJSON Sample where 
-instance FromJSON Sample where 
+instance ToJSON Sample where
+instance FromJSON Sample where
 
-instance Serialize Sample where  
+instance Serialize Sample where
   get = getFromJSON
   put = putToJSON
 
 initSample :: Sample
-initSample = Sample 0 
+initSample = Sample 0
 
 sampleStoreCellKey :: SampleCellKey
-sampleStoreCellKey =  CellKey { getKey = getKeyFcn 
+sampleStoreCellKey =  CellKey { getKey = getKeyFcn
                               , codeCellKeyFilename = fullEncodeFcn
                               , decodeCellKeyFilename = fullDecodeFcn
                               }
@@ -123,12 +123,12 @@ insertSampleSC :: SampleCell -> Sample -> IO (SimpleStore Sample)
 
 deleteSampleSC :: SampleCell -> SampleDirectedKey -> IO ()
 
-traverseWithKeySampleSC_ 
+traverseWithKeySampleSC_
   :: SampleCell
   -> (SampleCellKey -> SampleDirectedKey -> Sample -> IO ())
   -> IO ()
 
-foldlWithKeySampleSC 
+foldlWithKeySampleSC
   :: SampleCell
   -> (SampleCellKey -> SampleDirectedKey -> Sample -> IO b -> IO b)
   -> IO b
@@ -136,9 +136,11 @@ foldlWithKeySampleSC
 
 initializeSampleSC :: T.Text -> IO SampleCell
 
+initializeSampleWithErrorsSC :: T.Text -> IO (InitializedCell SampleKey SampleSrc SampleDst SampleTime Sample (SimpleStore CellKeyStore))
+
 getOrInsertSampleSC
   :: SampleCell
-  -> Sample 
+  -> Sample
   -> IO (SimpleStore Sample)
 getOrInsertSampleSC sc si = do
   maybeVal <- getSampleSC sc $ getKeyFcn si
@@ -149,29 +151,29 @@ getOrInsertSampleSC sc si = do
 runRestartTest :: [Int] -> IO [Int]
 runRestartTest i = do
   let sis = Sample <$> i
-  
+
   putStrLn "init first time"
   sc <- initializeSampleSC "testSampleCell"
-  
+
   putStrLn "traverse given list"
   void $ traverse (getOrInsertSampleSC sc) sis
-  
+
   putStrLn "first checkpiont and close"
   createCheckpointAndCloseSampleSC sc
-  
+
   putStrLn "init second time"
   sc' <- initializeSampleSC "testSampleCell"
-  
+
   putStrLn "list em"
   storeSamples <- traverse (getSampleSC sc' . getKeyFcn) sis
-  
+
   putStrLn "store em"
   samples <- traverse (traverse getSimpleStore) storeSamples
-    
+
   putStrLn "checkpoint"
   createCheckpointAndCloseSampleSC sc'
-  
+
   return $ sampleInt <$> (catMaybes samples)
 
 
-  
+


### PR DESCRIPTION
Instead of returning `SimpleCell`, we also return list of `StoreError` while reading multiple store. User can decide to act on the errors if there are any. This introduces new record `InitializedCell` to have both cell and errors.

For backward compatibility purpose, I am adding this as a new function `initializeXXXWithErrorsSC`.